### PR TITLE
Add RTCM protocol classes to the Domain layer

### DIFF
--- a/src/Application/Wangkanai.Caster.Application.csproj
+++ b/src/Application/Wangkanai.Caster.Application.csproj
@@ -1,3 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <ItemGroup>
+    <ProjectReference Include="..\Domain\Wangkanai.Caster.Domain.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Client/Wangkanai.Caster.Client.csproj
+++ b/src/Client/Wangkanai.Caster.Client.csproj
@@ -10,4 +10,8 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <ProjectReference Include="..\Domain\Wangkanai.Caster.Domain.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/src/Domain/Protocals/Rtcm.cs
+++ b/src/Domain/Protocals/Rtcm.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-namespace Wangkanai.Caster.Domain.Protocals;
-
+namespace Wangkanai.Caster.Domain.Protocols;
 public class Rtcm { }
 
 public class Rtcm2 : Rtcm { }

--- a/src/Domain/Protocals/Rtcm.cs
+++ b/src/Domain/Protocals/Rtcm.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Caster.Domain.Protocals;
+
+public class Rtcm { }
+
+public class Rtcm2 : Rtcm { }
+
+public class Rtcm3 : Rtcm { }

--- a/src/Infrastructure/Wangkanai.Caster.Infrastructure.csproj
+++ b/src/Infrastructure/Wangkanai.Caster.Infrastructure.csproj
@@ -1,3 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Wangkanai.Caster.Application.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Persistence/Wangkanai.Caster.Presistence.csproj
+++ b/src/Persistence/Wangkanai.Caster.Presistence.csproj
@@ -1,3 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure\Wangkanai.Caster.Infrastructure.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Server/Wangkanai.Caster.Server.csproj
+++ b/src/Server/Wangkanai.Caster.Server.csproj
@@ -15,5 +15,6 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Client\Wangkanai.Caster.Client.csproj" />
+		<ProjectReference Include="..\Persistence\Wangkanai.Caster.Presistence.csproj" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
### Description

Introduced foundational support for RTCM protocol handling by adding `Rtcm`, `Rtcm2`, and `Rtcm3` classes under the `Protocols` namespace in the Domain layer. This establishes a structured framework for representing RTCM protocol types.