### PR TITLE
Switch to xUnit v3 and initialize unit test setup

### DIFF
--- a/Caster.slnx
+++ b/Caster.slnx
@@ -11,7 +11,9 @@
     <File Path="Directory.Packages.props" />
     <File Path=".editorconfig" />
   </Folder>
-  <Folder Name="/tests/" />
+  <Folder Name="/tests/">
+    <Project Path="tests\Unit\Wangkanai.Caster.UnitTests.csproj" Type="Classic C#" />
+  </Folder>
   <Project Path="src\Application\Wangkanai.Caster.Application.csproj" Type="Classic C#" />
   <Project Path="src\Client\Wangkanai.Caster.Client.csproj" Type="Classic C#" />
   <Project Path="src\Domain\Wangkanai.Caster.Domain.csproj" Type="Classic C#" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,12 +11,19 @@
 	</ItemGroup>
 
 	<PropertyGroup Condition="$(MSBuildProjectName.Contains('Tests'))">
+		<OutputType>Exe</OutputType>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
+		<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+		<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(MSBuildProjectName.Contains('Tests'))">
 		<Using Include="Xunit"/>
+	</ItemGroup>
+
+	<ItemGroup Condition="$(MSBuildProjectName.Contains('Tests'))">
+		<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
 	</ItemGroup>
 
 	<!-- GitHub Source Link -->
@@ -27,9 +34,9 @@
 	<ItemGroup Condition="$(MSBuildProjectName.Contains('Tests'))">
 		<PackageReference Include="Microsoft.AspNetCore.TestHost"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
-		<PackageReference Include="Moq"/>
-		<PackageReference Include="xunit"/>
+		<PackageReference Include="xunit.v3"/>
 		<PackageReference Include="xunit.runner.visualstudio"/>
+		<PackageReference Include="Moq"/>
 		<PackageReference Include="coverlet.collector"/>
 		<PackageReference Include="coverlet.msbuild"/>
 		<PackageReference Include="FluentAssertions"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
 		<PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageVersion Include="Moq" Version="4.20.72" />
-		<PackageVersion Include="xunit" Version="2.9.3" />
+		<PackageVersion Include="xunit.v3" Version="2.0.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
 		<PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
 		<PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="all" />

--- a/tests/Unit/UnitTest1.cs
+++ b/tests/Unit/UnitTest1.cs
@@ -1,0 +1,10 @@
+namespace Wangkanai.Caster.UnitTests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+        Assert.True(true);
+    }
+}

--- a/tests/Unit/Wangkanai.Caster.UnitTests.csproj
+++ b/tests/Unit/Wangkanai.Caster.UnitTests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<RootNamespace>Wangkanai.Caster.UnitTests</RootNamespace>
+	</PropertyGroup>
+
+</Project>

--- a/tests/Unit/xunit.runner.json
+++ b/tests/Unit/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}


### PR DESCRIPTION
```
### Description:
- Upgraded test framework to xUnit version 3.
- Updated configurations to include `xunit.runner.json` and required build target properties.
- Added a placeholder unit test project with an initial basic test for infrastructure validation.

### Checklist:

- [ ] I have tested these changes locally.
- [ ] I have updated relevant documentation.
- [ ] I have checked my code and corrected any misspellings.
```