### PR TITLE
Add Rtcm constants and enum, update project references

### DIFF
--- a/Caster.slnx
+++ b/Caster.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/.github/">
     <File Path=".github\workflows\dotnet.yml" />
+    <File Path=".github\FUNDING.yml" />
   </Folder>
   <Folder Name="/.solutions/">
     <File Path="LICENSE" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,30 +1,31 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-		<FrameworkVersion>9.0.4</FrameworkVersion>
-	</PropertyGroup>
-	<ItemGroup>
-		<!--sourcelink-->
-		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<!--aspnet-->
-		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(FrameworkVersion)" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(FrameworkVersion)" />
-		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(FrameworkVersion)" />
-		<PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="$(FrameworkVersion)" />
-		<PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(FrameworkVersion)" />
-		<!--efcore-->
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(FrameworkVersion)" PrivateAssets="all" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(FrameworkVersion)" PrivateAssets="all" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(FrameworkVersion)" />
-		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-		<!--tests -->
-		<PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageVersion Include="Moq" Version="4.20.72" />
-		<PackageVersion Include="xunit.v3" Version="2.0.1" />
-		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
-		<PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
-		<PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="all" />
-		<PackageVersion Include="FluentAssertions" Version="8.2.0" />
-	</ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <FrameworkVersion>9.0.4</FrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <!--sourcelink-->
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <!--aspnet-->
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(FrameworkVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="$(FrameworkVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(FrameworkVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="$(FrameworkVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(FrameworkVersion)" />
+    <!--efcore-->
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(FrameworkVersion)" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(FrameworkVersion)" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(FrameworkVersion)" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <!--tests -->
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Wangkanai.System" Version="5.2.0" />
+    <PackageVersion Include="xunit.v3" Version="2.0.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="all" />
+    <PackageVersion Include="FluentAssertions" Version="8.2.0" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Wangkanai.Domain" Version="4.6.0" />
     <PackageVersion Include="Wangkanai.System" Version="5.2.0" />
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />

--- a/src/Domain/Protocals/Rtcm.cs
+++ b/src/Domain/Protocals/Rtcm.cs
@@ -1,8 +1,0 @@
-// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
-
-namespace Wangkanai.Caster.Domain.Protocols;
-public class Rtcm { }
-
-public class Rtcm2 : Rtcm { }
-
-public class Rtcm3 : Rtcm { }

--- a/src/Domain/Protocols/Rtcm.cs
+++ b/src/Domain/Protocols/Rtcm.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Caster.Domain.Protocols;
+
+public class Rtcm
+{
+	private const byte _preamble = 0x66; // 01100110
+	public const  int  n         = 32;
+	public const  int  k         = 10;
+	public const  int  d         = 4;
+
+	private enum MessageType : int
+	{
+		DifferentialGpsCorrections   = 1,
+		DeltaDifferentialCorrections = 2,
+		ReferenceStationStatus       = 3,
+		HighRateStationCorrections   = 9,
+	}
+}
+
+public class Rtcm2 : Rtcm { }
+
+public class Rtcm3 : Rtcm { }

--- a/src/Domain/Wangkanai.Caster.Domain.csproj
+++ b/src/Domain/Wangkanai.Caster.Domain.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	
   <ItemGroup>
+    <PackageReference Include="Wangkanai.Domain" />
     <PackageReference Include="Wangkanai.System" />
   </ItemGroup>
 

--- a/src/Domain/Wangkanai.Caster.Domain.csproj
+++ b/src/Domain/Wangkanai.Caster.Domain.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	
+  <ItemGroup>
+    <PackageReference Include="Wangkanai.System" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Unit/Wangkanai.Caster.UnitTests.csproj
+++ b/tests/Unit/Wangkanai.Caster.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<RootNamespace>Wangkanai.Caster.UnitTests</RootNamespace>
+		<RootNamespace>Wangkanai.Caster</RootNamespace>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Introduced constants and an internal enum to enhance the `Rtcm` class, improving clarity and code structure. Additionally, updated the project file to include a reference to `Wangkanai.System` for better package management.

This pull request includes significant changes to the `Rtcm` class and its associated classes, as well as modifications to the project file to include a new package reference.

### Changes to the `Rtcm` class:

* [`src/Domain/Protocols/Rtcm.cs`](diffhunk://#diff-18e5232c0af94b7c874dea743e534fa09f4695524bfa3e7c5d4d9fac48cc4dc0R1-R23): Added new constants and an enum to the `Rtcm` class to define message types and other properties. This enhances the functionality of the `Rtcm` class by providing more detailed definitions and structure.

### Project file modification:

* [`src/Domain/Wangkanai.Caster.Domain.csproj`](diffhunk://#diff-648746e363814fb598afc6211fb1622bb4da2412baeb27e524ec13d8010719fdL3-R5): Added a package reference to `Wangkanai.System`. This change ensures that the project has access to the necessary dependencies provided by the `Wangkanai.System` package.