### PR TITLE
Add PowerShell scripts for signing, versioning, and building

### DIFF
--- a/Caster.slnx
+++ b/Caster.slnx
@@ -11,6 +11,9 @@
     <File Path="Directory.Build.targets" />
     <File Path="Directory.Packages.props" />
     <File Path=".editorconfig" />
+    <File Path="build.ps1" />
+    <File Path="sign.ps1" />
+    <File Path="Version.ps1" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests\Functional\Wangkanai.Caster.FunctionalTests.csproj" Type="Classic C#" />

--- a/Version.ps1
+++ b/Version.ps1
@@ -1,0 +1,53 @@
+# Update package version in Directory.Build.props
+$name = "Wangkanai.Caster";
+$root = "D:\Sources\Caster\"
+$e = [char]27
+
+try {
+    [Xml]$xml = Get-Content -Path .\Directory.Build.props;
+    $version = $xml.Project.PropertyGroup.Version;
+    if ($version.GetType().FullName -ne "System.String") {
+        $version = $version[0];
+    }
+    Write-Host "Version:" $version -ForegroundColor Red;
+
+    $package = Find-Package -Name $name -ProviderName NuGet -AllVersions
+    $last = $package | Select-Object -First 1
+    $latest = $last.Version;
+
+    if ($latest -ne $version) {
+        Write-Host $latest " < " $version " Update" -ForegroundColor Green;
+        .\version.ps1 -dryrun $dryrun -certicate $certicate
+    }
+    else {
+        Write-Host $latest " = " $version " Skip" -ForegroundColor DarkGray;
+    }
+}
+catch {
+    Write-Host "New " $latest -ForegroundColor Blue;
+    .\sign.ps1 -dryrun $dryrun -certicate $certicate
+}
+
+if ($dryrun) {
+    Write-Host "Dryrun skip version update" -ForegroundColor Yellow;
+    exit;
+}
+
+try {
+    $path = $root + "Directory.Build.props";
+    $xml = New-Object System.Xml.XmlDocument
+    $xml.PreserveWhitespace = $true
+    $xml.Load($path);
+    $node = $xml.SelectSingleNode("/Project/PropertyGroup/Version");
+    $old = [System.Version]$node.InnerText;
+    $new = [System.Version]::new($old.Major, $old.Minor, $old.Build + 1); #0);
+    $node.InnerText = $new.ToString();
+    $xml.Save($path);
+
+    $result += [PSCustomObject]@{ NuGet = "$e[36m" + "$e[0m"; Version = "$e[32m$old => $new $e[0m" }
+}
+catch {
+    $result += [PSCustomObject]@{ NuGet = "$e[31m" + "$e[0m"; Version = "$e[31mError $e[0m" }
+}
+
+$result

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,4 @@
+dotnet --version
+dotnet clean   -c Release -tl
+dotnet restore
+dotnet build   -c Release -tl

--- a/sign.ps1
+++ b/sign.ps1
@@ -1,0 +1,36 @@
+param(
+    [Parameter(mandatory=$false)]
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$certicate="Open Source Developer, Sarin Na Wangkanai"
+)
+
+Write-Host "NuGet Certificate: $certicate"  -ForegroundColor Magenta
+
+Remove-Item -Path .\signed\*.*    -Force -ErrorAction SilentlyContinue
+Remove-Item -Path .\artifacts\*.* -Force -ErrorAction SilentlyContinue
+
+New-Item -Path artifacts -ItemType Directory -Force | Out-Null
+New-Item -Path signed    -ItemType Directory -Force | Out-Null
+
+dotnet --version
+dotnet clean    -c Release -tl
+dotnet restore
+dotnet build    -c Release -tl
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $certicate $_.FullName
+}
+
+dotnet pack -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
+
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $certicate -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $certicate -o .\signed
+
+if ($dryrun)
+{
+    Write-Host "Dryrun: Cryptography" -ForegroundColor Yellow;
+    exit;
+}
+
+dotnet nuget push .\signed\*.nupkg --skip-duplicate -k $env:NUGET_API_KEY  -s https://api.nuget.org/v3/index.json
+dotnet nuget push .\signed\*.nupkg --skip-duplicate -k $env:GITHUB_API_PAT -s https://nuget.pkg.github.com/wangkanai/index.json


### PR DESCRIPTION
This pull request introduces new PowerShell scripts to manage the build, versioning, and signing processes for the project. The most important changes include adding new files to the solution, implementing a version update script, creating a build script, and adding a signing script.

### New Scripts and Configuration Updates:

* [`Caster.slnx`](diffhunk://#diff-357827f3456d60a6c0ae2fecdcff67f95fd87bb07bcd692e74f29e69321979eaR14-R16): Added `build.ps1`, `sign.ps1`, and `Version.ps1` files to the solution.

* [`Version.ps1`](diffhunk://#diff-8b7fd7939dee8f7d15d6cdbb8fef118f35ec4fa3b452870eb479340b5dc19a26R1-R53): Implemented a script to update the package version in `Directory.Build.props`, compare it with the latest NuGet package version, and update the version if necessary.

* [`build.ps1`](diffhunk://#diff-3258bc4162690adead72c70b672093e68c92e86a4628148f0015d61738f21b5aR1-R4): Created a script to run `dotnet` commands for version checking, cleaning, restoring, and building the project in Release configuration.

* [`sign.ps1`](diffhunk://#diff-863a5e226c030bf68a67b477c7cec4fa67d61e98fe511b2825ac55cdab14e612R1-R36): Added a script to sign NuGet packages with a specified certificate, clean old artifacts, create necessary directories, and push signed packages to NuGet and GitHub.