### PR TITLE
Set initial project version in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.0.1</Version>
+		<Version>0.0.0</Version>
 		<Authors>Sarin Na Wangkanai</Authors>
 		<Company>Wangkanai</Company>
 		<Copyright>©2024-2025 Sarin Na Wangkanai, All rights reserv</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
+		<Version>0.0.1</Version>
 		<Authors>Sarin Na Wangkanai</Authors>
 		<Company>Wangkanai</Company>
 		<Copyright>©2024-2025 Sarin Na Wangkanai, All rights reserv</Copyright>


### PR DESCRIPTION
This pull request includes a small change to the `Directory.Build.props` file. The change adds a version property to the project metadata.

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR3): Added `<Version>0.0.0</Version>` to the project metadata.