### PR TITLE
Refine README.md for grammar, clarity, and consistency

### DIFF
--- a/Caster.slnx.DotSettings
+++ b/Caster.slnx.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ntrip/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rtcm/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<Version>0.0.0</Version>
 		<Authors>Sarin Na Wangkanai</Authors>
 		<Company>Wangkanai</Company>
-		<Copyright>©2024-2025 Sarin Na Wangkanai, All rights reserv</Copyright>
+		<Copyright>©2024-2025 Sarin Na Wangkanai, All rights reserved</Copyright>
 
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>git://github.com/wangkanai/caster</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,8 +25,8 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.Caster'">
-		<None Include="..\..\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
-		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 	<PropertyGroup>
@@ -39,6 +39,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
+		<RepoRoot Condition=" '$(RepoRoot)' == '' OR !HasTrailingSlash('$(RepoRoot)') ">$(MSBuildThisFileDirectory)</RepoRoot>
 		<SharedSourceRoot>$(MSBuildThisFileDirectory)Shared\src\</SharedSourceRoot>
 	</PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,13 +19,13 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <!--tests -->
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="xunit.v3" Version="2.0.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
+    <PackageVersion Include="xunit.v3" Version="2.0.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" PrivateAssets="all" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="all" />
-    <PackageVersion Include="FluentAssertions" Version="8.2.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.3.0" />
     <!--wangkanai-->
     <PackageVersion Include="Wangkanai.System" Version="5.6.0" />
     <PackageVersion Include="Wangkanai.Domain" Version="5.0.0-Beta-7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,12 +21,13 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Wangkanai.Domain" Version="4.6.0" />
-    <PackageVersion Include="Wangkanai.System" Version="5.2.0" />
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="all" />
     <PackageVersion Include="FluentAssertions" Version="8.2.0" />
+    <!--wangkanai-->
+    <PackageVersion Include="Wangkanai.System" Version="5.6.0" />
+    <PackageVersion Include="Wangkanai.Domain" Version="5.0.0-Beta-7" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,6 @@
     <PackageVersion Include="FluentAssertions" Version="8.3.0" />
     <!--wangkanai-->
     <PackageVersion Include="Wangkanai.System" Version="5.6.0" />
-    <PackageVersion Include="Wangkanai.Domain" Version="5.0.0-Beta-7" />
+    <PackageVersion Include="Wangkanai.Domain" Version="5.0.0-Beta-6" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <FrameworkVersion>9.0.4</FrameworkVersion>
+    <FrameworkVersion>9.0.6</FrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <!--sourcelink-->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wangkanai Caster Server
 
-A lightweight, high-performance NTRIP Caster Server built with .NET Core for distributing GNSS/GPS RTK correction data over the internet.
+Lightweight, high-performance NTRIP Caster Broadcast Server built with .NET Core for distributing GNSS/GPS RTK correction data over the internet.
 
 [![NuGet Version](https://img.shields.io/nuget/v/wangkanai.caster)](https://www.nuget.org/packages/wangkanai.caster)
 [![NuGet Pre Release](https://img.shields.io/nuget/vpre/wangkanai.caster)](https://www.nuget.org/packages/wangkanai.caster)
@@ -12,7 +12,7 @@ A lightweight, high-performance NTRIP Caster Server built with .NET Core for dis
 [![Patreon](https://img.shields.io/badge/patreon-support%20me-d9643a.svg)](https://www.patreon.com/wangkanai)
 [![GitHub](https://img.shields.io/github/license/wangkanai/caster)](https://github.com/wangkanai/caster/blob/main/LICENSE)
 
-## What is an NTRIP Caster?
+## What is a NTRIP Caster?
 
 NTRIP (Networked Transport of RTCM via Internet Protocol) is a protocol designed to stream GNSS correction data over the internet. An NTRIP Caster serves as the central hub that receives data from base stations and distributes it to rovers (like surveying equipment, precision agriculture tools, and drones) for enhanced positioning accuracy.
 
@@ -34,7 +34,7 @@ NTRIP (Networked Transport of RTCM via Internet Protocol) is a protocol designed
 ## Requirements
 
 - .NET 9.0 or later
-- Minimal hardware requirements - can run on low-spec devices
+- Minimal hardware requirements can run on low-spec devices
 - Internet connectivity for external source integration
 
 ## Installation
@@ -54,7 +54,7 @@ dotnet run
 ## Configuration
 
 Customize your caster instance through the simple configuration file:
-- Define your own mountpoints
+- Define your own mount points
 - Set up external source connections
 - Configure base station priorities
 - Adjust networking parameters


### PR DESCRIPTION
This pull request includes minor updates to configuration files, documentation, and project metadata. The most important changes involve correcting typos, updating framework versions, and refining descriptions in the README for clarity.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the description of the project to emphasize it as a "Broadcast Server" and corrected grammatical issues, such as "a NTRIP Caster" instead of "an NTRIP Caster" and rephrased hardware requirements for clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R37)

### Configuration and Metadata Updates:
* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L4-R4): Updated the `FrameworkVersion` property from `9.0.4` to `9.0.6` to reflect the latest framework version.
* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL6-R6): Fixed a typo in the copyright property, changing "reserv" to "reserved".
* [`Caster.slnx.DotSettings`](diffhunk://#diff-b7f0b7b2646980f9cacc73287886d30bbf96b024f6e3b159f98ff9f68b042af0R2): Added a new user dictionary entry for the word "ntrip" to improve IntelliSense and spell-checking support.