### PR TITLE
Simplify `sign.ps1` by removing redundant paths and parameters.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.0.0</Version>
+		<Version>0.0.1</Version>
 		<Authors>Sarin Na Wangkanai</Authors>
 		<Company>Wangkanai</Company>
 		<Copyright>©2024-2025 Sarin Na Wangkanai, All rights reserved</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,9 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.0.1</Version>
+		<Version>0.0.2</Version>
 		<Authors>Sarin Na Wangkanai</Authors>
 		<Company>Wangkanai</Company>
+		<Description>Lightweight, high-performance NTRIP Caster Broadcast Server built with .NET Core for distributing GNSS/GPS RTK correction data over the internet.</Description>
 		<Copyright>©2024-2025 Sarin Na Wangkanai, All rights reserved</Copyright>
 
 		<RepositoryType>git</RepositoryType>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.Caster'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.0.1</Version>
+		<Version>0.0.3</Version>
 		<Authors>Sarin Na Wangkanai</Authors>
 		<Company>Wangkanai</Company>
 		<Description>Lightweight, high-performance NTRIP Caster Broadcast Server built with .NET Core for distributing GNSS/GPS RTK correction data over the internet.</Description>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.0.2</Version>
+		<Version>0.0.1</Version>
 		<Authors>Sarin Na Wangkanai</Authors>
 		<Company>Wangkanai</Company>
 		<Description>Lightweight, high-performance NTRIP Caster Broadcast Server built with .NET Core for distributing GNSS/GPS RTK correction data over the internet.</Description>

--- a/sign.ps1
+++ b/sign.ps1
@@ -5,7 +5,6 @@ param(
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
-
 Write-Host "NuGet Certificate: $certicate"  -ForegroundColor Magenta
 
 Remove-Item -Path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/sign.ps1
+++ b/sign.ps1
@@ -15,14 +15,14 @@ New-Item -Path artifacts -ItemType Directory -Force | Out-Null
 New-Item -Path signed    -ItemType Directory -Force | Out-Null
 
 dotnet --version
-dotnet clean   .\src\ -c Release -tl
-dotnet restore .\src\
-dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+dotnet clean    -c Release -tl
+dotnet restore
+dotnet build    -c Release -tl
+Get-ChildItem   -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
-dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
+dotnet pack     -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed

--- a/src/Root/Wangkanai.Caster.csproj
+++ b/src/Root/Wangkanai.Caster.csproj
@@ -1,5 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Infrastructure\Wangkanai.Caster.Infrastructure.csproj" PrivateAssets="all" />
 	</ItemGroup>


### PR DESCRIPTION
This pull request makes improvements to the `sign.ps1` script by simplifying the `dotnet` commands and removing redundant path specifications. These changes streamline the script and make it more concise.

### Script simplifications:

* Removed unnecessary `.\srcThis pull request makes improvements to the `sign.ps1` script by simplifying the `dotnet` commands and removing redundant path specifications. These changes streamline the script and make it more concise.

### Script simplifications:

 path specification from `dotnet clean`, `dotnet restore`, `dotnet build`, and `dotnet pack` commands, as the commands now operate in the current directory by default. (`[sign.ps1L18-R25](diffhunk://#diff-863a5e226c030bf68a67b477c7cec4fa67d61e98fe511b2825ac55cdab14e612L18-R25)`)
* Adjusted the `Get-ChildItem` command to remove the `.\srcThis pull request makes improvements to the `sign.ps1` script by simplifying the `dotnet` commands and removing redundant path specifications. These changes streamline the script and make it more concise.

### Script simplifications:

* Removed unnecessary `.\srcThis pull request makes improvements to the `sign.ps1` script by simplifying the `dotnet` commands and removing redundant path specifications. These changes streamline the script and make it more concise.

### Script simplifications:

 path specification from `dotnet clean`, `dotnet restore`, `dotnet build`, and `dotnet pack` commands, as the commands now operate in the current directory by default. (`[sign.ps1L18-R25](diffhunk://#diff-863a5e226c030bf68a67b477c7cec4fa67d61e98fe511b2825ac55cdab14e612L18-R25)`)
 path and start the recursive search from the current directory, improving clarity and consistency. (`[sign.ps1L18-R25](diffhunk://#diff-863a5e226c030bf68a67b477c7cec4fa67d61e98fe511b2825ac55cdab14e612L18-R25)`)