### PR TITLE
Refactor namespaces from `Data` to `Identity`

### DIFF
--- a/src/Application/Identity/UserSeed.cs
+++ b/src/Application/Identity/UserSeed.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.AspNetCore.Identity;
 
-using Wangkanai.Caster.Data;
+using Wangkanai.Caster.Identity;
 
 namespace Wangkanai.Caster.Application.Identity;
 

--- a/src/Domain/Identity/CasterRole.cs
+++ b/src/Domain/Identity/CasterRole.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.AspNetCore.Identity;
 
-namespace Wangkanai.Caster.Data;
+namespace Wangkanai.Caster.Identity;
 
 public sealed class CasterRole : IdentityRole<Guid>
 {

--- a/src/Domain/Identity/CasterUser.cs
+++ b/src/Domain/Identity/CasterUser.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.AspNetCore.Identity;
 
-namespace Wangkanai.Caster.Data;
+namespace Wangkanai.Caster.Identity;
 
 // Add profile data for application users by adding properties to the ApplicationUser class
 public sealed class CasterUser : IdentityUser<Guid>

--- a/src/Persistence/CasterDbContext.cs
+++ b/src/Persistence/CasterDbContext.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 
-namespace Wangkanai.Caster.Identity;
+namespace Wangkanai.Caster.Persistence;
 
 public sealed class CasterDbContext(DbContextOptions<CasterDbContext> options)
 	: IdentityDbContext<CasterUser, CasterRole, Guid>(options)

--- a/src/Persistence/CasterDbContext.cs
+++ b/src/Persistence/CasterDbContext.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 
-namespace Wangkanai.Caster.Data;
+namespace Wangkanai.Caster.Identity;
 
 public sealed class CasterDbContext(DbContextOptions<CasterDbContext> options)
 	: IdentityDbContext<CasterUser, CasterRole, Guid>(options)

--- a/src/Server/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/Server/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using Wangkanai.Caster.Components.Account.Pages;
 using Wangkanai.Caster.Components.Account.Pages.Manage;
-using Wangkanai.Caster.Data;
+using Wangkanai.Caster.Identity;
 
 namespace Microsoft.AspNetCore.Routing;
 

--- a/src/Server/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/Server/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using Wangkanai.Caster.Components.Account.Pages;
 using Wangkanai.Caster.Components.Account.Pages.Manage;
-using Wangkanai.Caster.Identity;
+using Wangkanai.Caster.Persistence;
 
 namespace Microsoft.AspNetCore.Routing;
 

--- a/src/Server/Components/Account/IdentityNoOpEmailSender.cs
+++ b/src/Server/Components/Account/IdentityNoOpEmailSender.cs
@@ -3,7 +3,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 
-using Wangkanai.Caster.Data;
+using Wangkanai.Caster.Identity;
 
 namespace Wangkanai.Caster.Components.Account;
 

--- a/src/Server/Components/Account/IdentityNoOpEmailSender.cs
+++ b/src/Server/Components/Account/IdentityNoOpEmailSender.cs
@@ -3,7 +3,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 
-using Wangkanai.Caster.Identity;
+using Wangkanai.Caster.Persistence;
 
 namespace Wangkanai.Caster.Components.Account;
 

--- a/src/Server/Components/Account/IdentityRevalidatingAuthenticationStateProvider.cs
+++ b/src/Server/Components/Account/IdentityRevalidatingAuthenticationStateProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 
-using Wangkanai.Caster.Data;
+using Wangkanai.Caster.Identity;
 
 namespace Wangkanai.Caster.Components.Account;
 

--- a/src/Server/Components/Account/IdentityRevalidatingAuthenticationStateProvider.cs
+++ b/src/Server/Components/Account/IdentityRevalidatingAuthenticationStateProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 
-using Wangkanai.Caster.Identity;
+using Wangkanai.Caster.Persistence;
 
 namespace Wangkanai.Caster.Components.Account;
 

--- a/src/Server/Components/Account/IdentityUserAccessor.cs
+++ b/src/Server/Components/Account/IdentityUserAccessor.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
 using Microsoft.AspNetCore.Identity;
-using Wangkanai.Caster.Identity;
+using Wangkanai.Caster.Persistence;
 
 namespace Wangkanai.Caster.Components.Account;
 

--- a/src/Server/Components/Account/IdentityUserAccessor.cs
+++ b/src/Server/Components/Account/IdentityUserAccessor.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
 using Microsoft.AspNetCore.Identity;
-using Wangkanai.Caster.Data;
+using Wangkanai.Caster.Identity;
 
 namespace Wangkanai.Caster.Components.Account;
 

--- a/src/Server/Components/Account/Pages/ConfirmEmail.razor
+++ b/src/Server/Components/Account/Pages/ConfirmEmail.razor
@@ -3,7 +3,7 @@
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser> UserManager
 @inject IdentityRedirectManager      RedirectManager

--- a/src/Server/Components/Account/Pages/ConfirmEmail.razor
+++ b/src/Server/Components/Account/Pages/ConfirmEmail.razor
@@ -3,7 +3,7 @@
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser> UserManager
 @inject IdentityRedirectManager      RedirectManager

--- a/src/Server/Components/Account/Pages/ConfirmEmailChange.razor
+++ b/src/Server/Components/Account/Pages/ConfirmEmailChange.razor
@@ -3,7 +3,7 @@
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/ConfirmEmailChange.razor
+++ b/src/Server/Components/Account/Pages/ConfirmEmailChange.razor
@@ -3,7 +3,7 @@
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/ExternalLogin.razor
+++ b/src/Server/Components/Account/Pages/ExternalLogin.razor
@@ -6,7 +6,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject SignInManager<CasterUser> SignInManager
 @inject UserManager<CasterUser>   UserManager

--- a/src/Server/Components/Account/Pages/ExternalLogin.razor
+++ b/src/Server/Components/Account/Pages/ExternalLogin.razor
@@ -6,7 +6,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject SignInManager<CasterUser> SignInManager
 @inject UserManager<CasterUser>   UserManager

--- a/src/Server/Components/Account/Pages/ForgotPassword.razor
+++ b/src/Server/Components/Account/Pages/ForgotPassword.razor
@@ -5,7 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>  UserManager
 @inject IEmailSender<CasterUser> EmailSender

--- a/src/Server/Components/Account/Pages/ForgotPassword.razor
+++ b/src/Server/Components/Account/Pages/ForgotPassword.razor
@@ -5,7 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>  UserManager
 @inject IEmailSender<CasterUser> EmailSender

--- a/src/Server/Components/Account/Pages/Login.razor
+++ b/src/Server/Components/Account/Pages/Login.razor
@@ -3,7 +3,7 @@
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject SignInManager<CasterUser> SignInManager
 @inject ILogger<Login>                 Logger

--- a/src/Server/Components/Account/Pages/Login.razor
+++ b/src/Server/Components/Account/Pages/Login.razor
@@ -3,7 +3,7 @@
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject SignInManager<CasterUser> SignInManager
 @inject ILogger<Login>                 Logger

--- a/src/Server/Components/Account/Pages/LoginWith2fa.razor
+++ b/src/Server/Components/Account/Pages/LoginWith2fa.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject SignInManager<CasterUser> SignInManager
 @inject UserManager<CasterUser>   UserManager

--- a/src/Server/Components/Account/Pages/LoginWith2fa.razor
+++ b/src/Server/Components/Account/Pages/LoginWith2fa.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject SignInManager<CasterUser> SignInManager
 @inject UserManager<CasterUser>   UserManager

--- a/src/Server/Components/Account/Pages/LoginWithRecoveryCode.razor
+++ b/src/Server/Components/Account/Pages/LoginWithRecoveryCode.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject SignInManager<CasterUser> SignInManager
 @inject UserManager<CasterUser>   UserManager

--- a/src/Server/Components/Account/Pages/LoginWithRecoveryCode.razor
+++ b/src/Server/Components/Account/Pages/LoginWithRecoveryCode.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject SignInManager<CasterUser> SignInManager
 @inject UserManager<CasterUser>   UserManager

--- a/src/Server/Components/Account/Pages/Manage/ChangePassword.razor
+++ b/src/Server/Components/Account/Pages/Manage/ChangePassword.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/ChangePassword.razor
+++ b/src/Server/Components/Account/Pages/Manage/ChangePassword.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/DeletePersonalData.razor
+++ b/src/Server/Components/Account/Pages/Manage/DeletePersonalData.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/DeletePersonalData.razor
+++ b/src/Server/Components/Account/Pages/Manage/DeletePersonalData.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/Disable2fa.razor
+++ b/src/Server/Components/Account/Pages/Manage/Disable2fa.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Account/Manage/Disable2fa"
 
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser> UserManager
 @inject IdentityUserAccessor         UserAccessor

--- a/src/Server/Components/Account/Pages/Manage/Disable2fa.razor
+++ b/src/Server/Components/Account/Pages/Manage/Disable2fa.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Account/Manage/Disable2fa"
 
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser> UserManager
 @inject IdentityUserAccessor         UserAccessor

--- a/src/Server/Components/Account/Pages/Manage/Email.razor
+++ b/src/Server/Components/Account/Pages/Manage/Email.razor
@@ -5,7 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>  UserManager
 @inject IEmailSender<CasterUser> EmailSender

--- a/src/Server/Components/Account/Pages/Manage/Email.razor
+++ b/src/Server/Components/Account/Pages/Manage/Email.razor
@@ -5,7 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>  UserManager
 @inject IEmailSender<CasterUser> EmailSender

--- a/src/Server/Components/Account/Pages/Manage/EnableAuthenticator.razor
+++ b/src/Server/Components/Account/Pages/Manage/EnableAuthenticator.razor
@@ -5,7 +5,7 @@
 @using System.Text
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser> UserManager
 @inject IdentityUserAccessor         UserAccessor

--- a/src/Server/Components/Account/Pages/Manage/EnableAuthenticator.razor
+++ b/src/Server/Components/Account/Pages/Manage/EnableAuthenticator.razor
@@ -5,7 +5,7 @@
 @using System.Text
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser> UserManager
 @inject IdentityUserAccessor         UserAccessor

--- a/src/Server/Components/Account/Pages/Manage/ExternalLogins.razor
+++ b/src/Server/Components/Account/Pages/Manage/ExternalLogins.razor
@@ -2,7 +2,7 @@
 
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/ExternalLogins.razor
+++ b/src/Server/Components/Account/Pages/Manage/ExternalLogins.razor
@@ -2,7 +2,7 @@
 
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/GenerateRecoveryCodes.razor
+++ b/src/Server/Components/Account/Pages/Manage/GenerateRecoveryCodes.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Account/Manage/GenerateRecoveryCodes"
 
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject IdentityUserAccessor           UserAccessor

--- a/src/Server/Components/Account/Pages/Manage/GenerateRecoveryCodes.razor
+++ b/src/Server/Components/Account/Pages/Manage/GenerateRecoveryCodes.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Account/Manage/GenerateRecoveryCodes"
 
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject IdentityUserAccessor           UserAccessor

--- a/src/Server/Components/Account/Pages/Manage/Index.razor
+++ b/src/Server/Components/Account/Pages/Manage/Index.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/Index.razor
+++ b/src/Server/Components/Account/Pages/Manage/Index.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/ResetAuthenticator.razor
+++ b/src/Server/Components/Account/Pages/Manage/ResetAuthenticator.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Account/Manage/ResetAuthenticator"
 
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/ResetAuthenticator.razor
+++ b/src/Server/Components/Account/Pages/Manage/ResetAuthenticator.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Account/Manage/ResetAuthenticator"
 
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/SetPassword.razor
+++ b/src/Server/Components/Account/Pages/Manage/SetPassword.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/SetPassword.razor
+++ b/src/Server/Components/Account/Pages/Manage/SetPassword.razor
@@ -2,7 +2,7 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/TwoFactorAuthentication.razor
+++ b/src/Server/Components/Account/Pages/Manage/TwoFactorAuthentication.razor
@@ -2,7 +2,7 @@
 
 @using Microsoft.AspNetCore.Http.Features
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Manage/TwoFactorAuthentication.razor
+++ b/src/Server/Components/Account/Pages/Manage/TwoFactorAuthentication.razor
@@ -2,7 +2,7 @@
 
 @using Microsoft.AspNetCore.Http.Features
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject SignInManager<CasterUser> SignInManager

--- a/src/Server/Components/Account/Pages/Register.razor
+++ b/src/Server/Components/Account/Pages/Register.razor
@@ -5,7 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>   UserManager
 @inject IUserStore<CasterUser>    UserStore

--- a/src/Server/Components/Account/Pages/Register.razor
+++ b/src/Server/Components/Account/Pages/Register.razor
@@ -5,7 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>   UserManager
 @inject IUserStore<CasterUser>    UserStore

--- a/src/Server/Components/Account/Pages/RegisterConfirmation.razor
+++ b/src/Server/Components/Account/Pages/RegisterConfirmation.razor
@@ -3,7 +3,7 @@
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>  UserManager
 @inject IEmailSender<CasterUser> EmailSender

--- a/src/Server/Components/Account/Pages/RegisterConfirmation.razor
+++ b/src/Server/Components/Account/Pages/RegisterConfirmation.razor
@@ -3,7 +3,7 @@
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>  UserManager
 @inject IEmailSender<CasterUser> EmailSender

--- a/src/Server/Components/Account/Pages/ResendEmailConfirmation.razor
+++ b/src/Server/Components/Account/Pages/ResendEmailConfirmation.razor
@@ -5,7 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject UserManager<CasterUser>  UserManager
 @inject IEmailSender<CasterUser> EmailSender

--- a/src/Server/Components/Account/Pages/ResendEmailConfirmation.razor
+++ b/src/Server/Components/Account/Pages/ResendEmailConfirmation.razor
@@ -5,7 +5,7 @@
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject UserManager<CasterUser>  UserManager
 @inject IEmailSender<CasterUser> EmailSender

--- a/src/Server/Components/Account/Pages/ResetPassword.razor
+++ b/src/Server/Components/Account/Pages/ResetPassword.razor
@@ -4,7 +4,7 @@
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject IdentityRedirectManager      RedirectManager
 @inject UserManager<CasterUser> UserManager

--- a/src/Server/Components/Account/Pages/ResetPassword.razor
+++ b/src/Server/Components/Account/Pages/ResetPassword.razor
@@ -4,7 +4,7 @@
 @using System.Text
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject IdentityRedirectManager      RedirectManager
 @inject UserManager<CasterUser> UserManager

--- a/src/Server/Components/Account/Shared/ExternalLoginPicker.razor
+++ b/src/Server/Components/Account/Shared/ExternalLoginPicker.razor
@@ -1,6 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject SignInManager<CasterUser> SignInManager
 @inject IdentityRedirectManager        RedirectManager

--- a/src/Server/Components/Account/Shared/ExternalLoginPicker.razor
+++ b/src/Server/Components/Account/Shared/ExternalLoginPicker.razor
@@ -1,6 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject SignInManager<CasterUser> SignInManager
 @inject IdentityRedirectManager        RedirectManager

--- a/src/Server/Components/Account/Shared/ManageNavMenu.razor
+++ b/src/Server/Components/Account/Shared/ManageNavMenu.razor
@@ -1,5 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Data
+@using Wangkanai.Caster.Identity
 
 @inject SignInManager<CasterUser> SignInManager
 

--- a/src/Server/Components/Account/Shared/ManageNavMenu.razor
+++ b/src/Server/Components/Account/Shared/ManageNavMenu.razor
@@ -1,5 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Identity
-@using Wangkanai.Caster.Identity
+@using Wangkanai.Caster.Persistence
 
 @inject SignInManager<CasterUser> SignInManager
 

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Wangkanai.Caster.Client.Pages;
 using Wangkanai.Caster.Components;
 using Wangkanai.Caster.Components.Account;
-using Wangkanai.Caster.Identity;
+using Wangkanai.Caster.Persistence;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Wangkanai.Caster.Client.Pages;
 using Wangkanai.Caster.Components;
 using Wangkanai.Caster.Components.Account;
-using Wangkanai.Caster.Data;
+using Wangkanai.Caster.Identity;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Server/Usings.cs
+++ b/src/Server/Usings.cs
@@ -1,4 +1,3 @@
 // Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-global using Microsoft.EntityFrameworkCore;
 global using Wangkanai.Caster.Identity;


### PR DESCRIPTION
This pull request refactors the namespace `Wangkanai.Caster.Data` to `Wangkanai.Caster.Identity` across multiple files in the project. The changes aim to improve code organization and better reflect the purpose of the `Identity` components.

### Namespace Refactoring
* Updated the namespace from `Wangkanai.Caster.Data` to `Wangkanai.Caster.Identity` in the following files:
  - `src/Application/Identity/UserSeed.cs`
  - `src/Domain/Identity/CasterRole.cs`
  - `src/Domain/Identity/CasterUser.cs`
  - `src/Persistence/CasterDbContext.cs`
  - Various files under `src/Server/Components/Account/` including `IdentityComponentsEndpointRouteBuilderExtensions.cs`, `IdentityNoOpEmailSender.cs`, `IdentityRevalidatingAuthenticationStateProvider.cs`, `IdentityUserAccessor.cs`, and multiple `.razor` files for account management and authentication [[1]](diffhunk://#diff-2ad5e51711f512836f678cb6b41de614eaf4c3f7899c45d48e2f328085fee040L13-R13) [[2]](diffhunk://#diff-b255e1a77818acea90d4993ffb958d7b0185653c4b40e7aa958d92cebe7acbf6L6-R6) [[3]](diffhunk://#diff-adc1839195f76f77a1b931afc449b277dbc1dd077fbaf179023793b8cf483ab3L10-R10) [[4]](diffhunk://#diff-ef04ddfd7843f313e1466bd529766048b81402397a97eb39e73597e045a6a3d8L4-R4) [[5]](diffhunk://#diff-487534a8f9e3bdcd0c7bc5ebac1cc8d1cb966ef6dcd67e4f272e2d49f0d1d8f0L6-R6) [[6]](diffhunk://#diff-15fc196ad8399f4739c2fc3112d3433dad200c37b47e47b6eedda74909a88a37L6-R6) [[7]](diffhunk://#diff-bc84ae42683aab9d5f66bea9e274a11eed97fdbde6f84fdd74cbe722e105e05aL9-R9) [[8]](diffhunk://#diff-e0aa07bf12439927207c21349fb31eaa434c195b25a1ec10a7c501008fcbb311L8-R8) [[9]](diffhunk://#diff-f63c3cdb3656fc2a07b9f63bc03d11e49e14a69f2a452c9040fa157b9c7f5f02L6-R6) [[10]](diffhunk://#diff-14649ddf3f1f95f917f890e7ca324ea7f51a1025172809dcafd6d3456a5555c0L5-R5) [[11]](diffhunk://#diff-fde633aea25dc0e66fb4f6870b5b1476d840a34d063f511637d6a23f71121538L5-R5) [[12]](diffhunk://#diff-c39fc7cf7dafbdb55454d35322d6b7986d3d7b5eeeaceccf2bc8b31ae0537071L5-R5) [[13]](diffhunk://#diff-31101f30b33ec0f72bc793cb75716f7505243b5656193c8405c05ac5ed9aedb3L5-R5) [[14]](diffhunk://#diff-2cd7ab17254664ec25472e110cd8fbd34bbeca2657bc3bbf5e87e790cfa64a28L4-R4) [[15]](diffhunk://#diff-2c2024a42c024a34e367102e0fc689421c20d8f7965cf001ebd9b5d3cb234077L8-R8) [[16]](diffhunk://#diff-e4a7afb43c5d628eb297e0ec70252dace009e8be8467b8c430eb3df4787083b9L8-R8).

This change ensures consistency in the namespace used for identity-related components and improves the clarity of the project's structure.